### PR TITLE
Referencias únicas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :deployment do
 end
 
 group :development, :test do
-  gem 'pry'
+  gem 'pry-rails'
   gem 'forgery'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     cocaine (0.2.1)
-    coderay (0.9.8)
+    coderay (1.1.1)
     dbf (1.7.2)
       fastercsv (~> 1.5.4)
     devise (1.5.4)
@@ -87,8 +87,7 @@ GEM
       activerecord (~> 3.0.2)
       activesupport (~> 3.0.2)
       arel (~> 2.0.2)
-    method_source (0.6.7)
-      ruby_parser (>= 2.3.1)
+    method_source (0.8.2)
     mime-types (1.17.2)
     money (4.0.1)
       i18n (~> 0.4)
@@ -113,11 +112,12 @@ GEM
     prawn (0.12.0)
       pdf-reader (>= 0.9.0)
       ttfunk (~> 1.0.2)
-    pry (0.9.7.4)
-      coderay (~> 0.9.8)
-      method_source (~> 0.6.7)
-      ruby_parser (>= 2.3.1)
-      slop (~> 2.1.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     rack (1.2.8)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
@@ -141,10 +141,7 @@ GEM
     rdoc (3.12)
       json (~> 1.4)
     responders (0.6.4)
-    ruby_parser (2.3.1)
-      sexp_processor (~> 3.0)
-    sexp_processor (3.0.10)
-    slop (2.1.0)
+    slop (3.6.0)
     squeezer (0.2.1)
     sshkit (1.12.0)
       net-scp (>= 1.1.2)
@@ -185,7 +182,7 @@ DEPENDENCIES
   paperclip
   passenger
   prawn
-  pry
+  pry-rails
   rails (= 3.0.20)
   squeezer (= 0.2.1)
   test-unit

--- a/app/models/reserva.rb
+++ b/app/models/reserva.rb
@@ -61,6 +61,11 @@ class Reserva < ActiveRecord::Base
   validates :agency_id, :presence => true
   validates :total, :presence => true
 
+  # la referencia debe ser única, excepto en el caso en que no existe (algunas
+  # operadoras no tienen número de referencia)
+  validates_uniqueness_of :referencia, allow_blank: true,
+                                       message: 'ya está cargada'
+
   validate :monto_total_si_hay_pagos, :on => :update
   #scopes
 


### PR DESCRIPTION
Para evitar reservas duplicadas, se agrega una validación de unicidad en referencia, pero se permiten referencias en blanco (porque algunas operadoras no tienen número de referencia)