### PR TITLE
FIX: format_monto y monto_final en movimiento

### DIFF
--- a/app/models/deposito.rb
+++ b/app/models/deposito.rb
@@ -22,16 +22,6 @@ class Deposito < Movimiento
   # Asociaciones
   #
   belongs_to :tdeposito
-  monetize   :monto
-  monetize   :monto_final
-
-  def format_monto
-    if self.monto == self.monto_final
-      self.monto_final.format
-    else
-      "#{self.monto.format} -> #{self.monto_final.format}"
-    end
-  end
 
   private
 

--- a/app/models/movimiento.rb
+++ b/app/models/movimiento.rb
@@ -30,6 +30,18 @@ class Movimiento < ActiveRecord::Base
   scope :baja, where(:hidden=>0)
 
   # metodos
+
+  monetize   :monto
+  monetize   :monto_final
+
+  def format_monto
+    if self.monto == self.monto_final
+      self.monto_final.format
+    else
+      "#{self.monto.format} -> #{self.monto_final.format}"
+    end
+  end
+
   def self.total(movs)
     movs = movs.group_by { |m| m.monto.currency_as_string }
     totales = {}


### PR DESCRIPTION
Al parecer, para poder mostrar los Pagos (que ya no se usan) se necesita
que funcionen más o menos como depósitos, así que muevo los métodos a
movimiento para que estén disponibles en todos lados.